### PR TITLE
Fixes for two NES keyboard issues

### DIFF
--- a/src/app/screen_wnd.ts
+++ b/src/app/screen_wnd.ts
@@ -92,6 +92,7 @@ const kKeyMapping: {[key: string]: KeyType} = {
   BracketRight: KeyType.RBRACKET,
   Escape: KeyType.ESC,
   Semicolon: KeyType.SEMICOLON,
+  Quote: KeyType.COLON,
   Minus: KeyType.MINUS,
   Equal: KeyType.HAT,
   Backslash: KeyType.YEN,
@@ -341,6 +342,7 @@ export class ScreenWnd extends Wnd {
         this.timeScale = TIME_SCALE_NORMAL
         this.padKeyHandler.clearAll()
         this.domKeyboardManager.clear()
+        this.nesKeyboard?.clearAll()
       }
       break
 

--- a/src/nes/peripheral/keyboard.ts
+++ b/src/nes/peripheral/keyboard.ts
@@ -24,7 +24,7 @@ export class Keyboard implements Peripheral {
   private rowcol = 0
 
   constructor() {
-    this.state.fill(0x1e)
+    this.clearAll()
 
     this.ioMap.set(0x4016, (_adr: Address, value?: Byte) => {
       if (value != null) {
@@ -56,5 +56,9 @@ export class Keyboard implements Peripheral {
     const b = 2 << (type & 3)
     const s = this.state[i]
     this.state[i] = pressed ? (s & ~b) : (s | b)  // Pressed=>clear, not pressed=>set
+  }
+
+  public clearAll(): void {
+    this.state.fill(0x1e)
   }
 }


### PR DESCRIPTION
There are two issues addressed by this pull request:

 1. There is no key code mapped to the NES keyboard's colon (:) character.. There is no way to type this, but it is an important character in Family BASIC (for separating multiple commands in a single line) I used the apostrophe (Quote) key, as this is what Mesen also uses, and its placement (at least on my keyboard and many others) is appropriate to where the colon key is on the NES keyboard.
 2. A key that is pressed when the browser window or tab loses focus, will remain pressed indefinitely. The biggest trigger of this problem for me is Alt-Tab to switch to a different program - this causes the NES keyboard to hold down the Graph key. Typing most keys then produces no input to the NES, unless I hit LeftTab again to clear the state of the Graph key. This same issue was already fixed for gamepad button keys; I fixed it for NES keyboard in the same way.