### PR TITLE
Fix: Allow both keyboard and gamepad to work

### DIFF
--- a/src/nes/nes.ts
+++ b/src/nes/nes.ts
@@ -255,14 +255,15 @@ export class Nes {
     })
 
     bus.setReadMemory(0x4000, 0x5fff, adr => {
+      let val = 0
       if (this.peripheralMap.has(adr))
-        return this.peripheralMap.get(adr)!(adr)
-      return this.readFromApu(adr)  // APU
+        val = this.peripheralMap.get(adr)!(adr)
+      val |= this.readFromApu(adr)  // APU
+      return val
     })
     bus.setWriteMemory(0x4000, 0x5fff, (adr, value) => {
       if (this.peripheralMap.has(adr)) {
         this.peripheralMap.get(adr)!(adr, value)
-        return
       }
       this.writeToApu(adr, value)  // APU
     })


### PR DESCRIPTION
When Family BASIC is running (keyboard attached), the gamepad no longer works. The reason for this is that the keyboard peripheral masks out the APU registers at $4016 and $4017, so that only the keyboard may be read, and not the gamepad.

My solution for this is to ensure that both the peripheral *and* the gamepad both receive reads and writes. For writes, this is trivial; for reads, I bitwise-OR values from both the keyboard and the gamepad. This works!

I tested that pressing keys does not interfere with reading the gamepad (as tested in Family BASIC via `10 ? STICK(0), STRIG(0):GOTO 10`) (except keys that are mapped as gamepad keys, of course), and similarly, manipulating the controller keys and buttons does not interfere reading keyboard input.

I separated this fix out from the other two keyboard-related fixes, because I'm not 100% confident on it. While everything appears to function correctly from a high-level view, it's unclear to me whether "ORing the two reads" is authentic to what hardware actually does. Still, neither should be giving values when they weren't first signaled that we wish to read from it - the gamepad in particular needs to be sent the signal to latch its values.

I didn't test with player 2 gamepad; it could be that it's more likely to suffer problems, since one reads from the same register as for the keyboard ($4017). Still, I imagine that once the keyboard has finished sending values for a requested row, it stops sending anything on subsequent reads until the appropriate value is written to $4016 again?