### PR TITLE
Fix the About window

### DIFF
--- a/src/app/other_wnd.ts
+++ b/src/app/other_wnd.ts
@@ -16,7 +16,7 @@ import {Util} from '../util/util'
 import * as Pubsub from '../util/pubsub'
 import {default as Stats} from 'stats-js'
 
-import aboutHtmlContent from '../res/about.html?inline'
+import aboutHtmlContent from '../res/about.html?inline&raw'
 import githubLogoSvg from '../res/github-logo.svg?raw'
 
 import pluseImg from '../res/pulse.png'


### PR DESCRIPTION
Currently, when one opens the "About" window (via the start menu), it displays the string `[object Promise]`. This PR fixes the issue, and displays the intended message and GitHub icon.